### PR TITLE
disable visuals inside dumb terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,17 @@ function PleasantProgress(options) {
 PleasantProgress.prototype.start = function(message, stepString) {
   this.message = message;
   this.stepString = stepString || '.';
-  this.stop();
-  this.isRunning = true;
-  this.print();
-  this.stepInterval = setInterval(this.step.bind(this), this.rate);
+  if (!/^(dumb|emacs)$/.test(process.env.TERM)) {
+    this.stop();
+    this.isRunning = true;
+    this.print();
+    this.stepInterval = setInterval(this.step.bind(this), this.rate);
+  }
+  else {
+    this.progress = 3;
+    this.print();
+    this.stream.write('\n');
+  }
 };
 
 PleasantProgress.prototype.stop = function(printWithFullStepString) {


### PR DESCRIPTION
I'm working on some editor integration for ember-cli and they configure the environment with `TERM=dumb` (or in emacs case it sets `TERM=emacs` in compilation mode) to indicate that terminal cursor movement won't work. This should also work for #2 if you configure `TERM=dumb` inside the ci environment.
